### PR TITLE
fix: deploy pre-built functions to avoid Cloud Build compilation issues

### DIFF
--- a/.github/workflows/deploy-contact-function.yml
+++ b/.github/workflows/deploy-contact-function.yml
@@ -87,13 +87,26 @@ jobs:
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Create deployment package
+        run: |
+          cd functions
+          # Create a clean deployment directory
+          mkdir -p deploy
+          # Copy only necessary files for deployment
+          cp package.json deploy/
+          cp package-lock.json deploy/ 2>/dev/null || cp ../package-lock.json deploy/
+          cp -r dist deploy/
+          cp -r node_modules deploy/ 2>/dev/null || true
+          # Create a minimal package.json without gcp-build to skip compilation
+          jq 'del(.scripts["gcp-build"]) | del(.devDependencies)' package.json > deploy/package.json
+
       - name: Deploy to Cloud Functions (Staging)
         run: |
           gcloud functions deploy ${{ env.FUNCTION_NAME }}-staging \
             --gen2 \
             --runtime=nodejs20 \
             --region=${{ env.FUNCTION_REGION }} \
-            --source=functions \
+            --source=functions/deploy \
             --entry-point=handleContactForm \
             --trigger-http \
             --allow-unauthenticated \
@@ -156,13 +169,26 @@ jobs:
         with:
           project_id: ${{ env.GCP_PROJECT_ID }}
 
+      - name: Create deployment package
+        run: |
+          cd functions
+          # Create a clean deployment directory
+          mkdir -p deploy
+          # Copy only necessary files for deployment
+          cp package.json deploy/
+          cp package-lock.json deploy/ 2>/dev/null || cp ../package-lock.json deploy/
+          cp -r dist deploy/
+          cp -r node_modules deploy/ 2>/dev/null || true
+          # Create a minimal package.json without gcp-build to skip compilation
+          jq 'del(.scripts["gcp-build"]) | del(.devDependencies)' package.json > deploy/package.json
+
       - name: Deploy to Cloud Functions (Production)
         run: |
           gcloud functions deploy ${{ env.FUNCTION_NAME }} \
             --gen2 \
             --runtime=nodejs20 \
             --region=${{ env.FUNCTION_REGION }} \
-            --source=functions \
+            --source=functions/deploy \
             --entry-point=handleContactForm \
             --trigger-http \
             --allow-unauthenticated \


### PR DESCRIPTION
Changes deployment strategy to skip TypeScript compilation on Cloud Build:
- Build TypeScript locally in GitHub Actions
- Create clean deployment package with compiled dist/ directory
- Remove gcp-build script and devDependencies from deployed package.json
- Deploy from functions/deploy directory with pre-built code

This avoids Cloud Build failures and speeds up deployment by skipping unnecessary compilation step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)