### PR TITLE
refactor: send email before Firestore and capture Mailgun response

### DIFF
--- a/functions/src/services/email.service.ts
+++ b/functions/src/services/email.service.ts
@@ -136,8 +136,13 @@ export class EmailService {
 
   /**
    * Send contact form notification email
+   * Returns Mailgun response for storage in Firestore
    */
-  async sendContactFormNotification(data: ContactFormNotificationData): Promise<void> {
+  async sendContactFormNotification(data: ContactFormNotificationData): Promise<{
+    messageId: string
+    status?: string
+    accepted: boolean
+  }> {
     try {
       const client = await this.initializeMailgun()
       const config = await this.getEmailConfig()
@@ -163,6 +168,12 @@ export class EmailService {
         name: data.name,
         note: "Email accepted by Mailgun - check Mailgun logs for final delivery status",
       })
+
+      return {
+        messageId: result.id || "unknown",
+        status: result.status ? String(result.status) : undefined,
+        accepted: true,
+      }
     } catch (error) {
       this.logger.error("Failed to send notification email", {
         error,

--- a/functions/src/services/firestore.service.ts
+++ b/functions/src/services/firestore.service.ts
@@ -19,6 +19,12 @@ export interface ContactSubmission {
   requestId: string
   traceId?: string
   spanId?: string
+  mailgun?: {
+    messageId: string
+    status?: string
+    accepted?: boolean
+    deliveryStatus?: string
+  }
   status: "new" | "read" | "replied" | "spam"
   createdAt: Date
   updatedAt: Date


### PR DESCRIPTION
Changes to execution order:
1. STEP 1: Send email notification (critical - must succeed)
2. STEP 2: Save to Firestore with Mailgun response (non-blocking)
3. STEP 3: Send auto-reply (non-blocking)

Benefits:
- Email is sent first (primary function)
- Mailgun response captured in Firestore for debugging
- Firestore failures don't affect email delivery
- Better debugging with Mailgun messageId stored in document

ContactSubmission interface additions:
- mailgun.messageId: Mailgun's unique message ID
- mailgun.status: HTTP status from Mailgun API
- mailgun.accepted: Whether email was accepted for delivery
- mailgun.deliveryStatus: Optional final delivery status

EmailService changes:
- sendContactFormNotification now returns Mailgun response
- Response includes messageId, status, accepted flag
- Type-safe handling of Mailgun API response

Example Firestore document now includes:
{
  "requestId": "req_123", "traceId": "abc123", "spanId": "def456", "mailgun": { "messageId": "<20251006.1@mailgun.org>", "status": "200", "accepted": true } }

This makes debugging much easier - you can see Mailgun's response directly in the Firestore document without checking logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)